### PR TITLE
Add name to metadata, explicit recipe definitions

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -6,11 +6,11 @@ description       "Installs Ruby and related packages"
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version           "0.9.2"
 
-recipe "ruby", "Installs Ruby and related packages"
-recipe "1.8", "Installs Ruby 1.8 and related packages"
-recipe "1.9", "Installs Ruby 1.9 and related packages"
-recipe "1.9.1", "Installs Ruby 1.9.1 and related packages"
-recipe "symlinks", "Installs symlinks for the default Ruby version"
+recipe "ruby::default",   "Installs Ruby and related packages"
+recipe "ruby::1.8",       "Installs Ruby 1.8 and related packages"
+recipe "ruby::1.9",       "Installs Ruby 1.9 and related packages"
+recipe "ruby::1.9.1",     "Installs Ruby 1.9.1 and related packages"
+recipe "ruby::symlinks",  "Installs symlinks for the default Ruby version"
 
 attribute "languages/ruby/default_version",
  :display_name => "Default Ruby version",


### PR DESCRIPTION
Add (cookbook) name attribute, mostly because the cookbook lies in a repos/folder that has a different name to save incorrect inferences. Define the recipes more explicitly/in full.
